### PR TITLE
Add link-based tunnel import

### DIFF
--- a/Sources/WireGuardApp/Base.lproj/Localizable.strings
+++ b/Sources/WireGuardApp/Base.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "actionOK" = "OK";
 "actionCancel" = "Cancel";
 "actionSave" = "Save";
+"actionConnect" = "Connect";
 
 // Tunnels list UI
 
@@ -25,6 +26,7 @@
 "addTunnelMenuImportFile" = "Create from file or archive";
 "addTunnelMenuQRCode" = "Create from QR code";
 "addTunnelMenuFromScratch" = "Create from scratch";
+"addTunnelMenuFromLink" = "Create from link";
 
 // Tunnels list alerts
 
@@ -36,6 +38,7 @@
 
 "alertBadConfigImportTitle" = "Unable to import tunnel";
 "alertBadConfigImportMessage (%@)" = "The file ‘%@’ does not contain a valid WireGuard configuration";
+"alertInvalidURLErrorMessage" = "The link is invalid";
 
 "deleteTunnelsConfirmationAlertButtonTitle" = "Delete";
 "deleteTunnelConfirmationAlertButtonMessage (%d)" = "Delete %d tunnel?";

--- a/Sources/WireGuardApp/UI/iOS/ViewController/TunnelsListTableViewController.swift
+++ b/Sources/WireGuardApp/UI/iOS/ViewController/TunnelsListTableViewController.swift
@@ -148,6 +148,11 @@ class TunnelsListTableViewController: UIViewController {
         }
         alert.addAction(scanQRCodeAction)
 
+        let importLinkAction = UIAlertAction(title: tr("addTunnelMenuFromLink"), style: .default) { [weak self] _ in
+            self?.presentViewControllerForLinkImport()
+        }
+        alert.addAction(importLinkAction)
+
         let createFromScratchAction = UIAlertAction(title: tr("addTunnelMenuFromScratch"), style: .default) { [weak self] _ in
             if let self = self, let tunnelsManager = self.tunnelsManager {
                 self.presentViewControllerForTunnelCreation(tunnelsManager: tunnelsManager)
@@ -196,6 +201,58 @@ class TunnelsListTableViewController: UIViewController {
         let scanQRCodeNC = UINavigationController(rootViewController: scanQRCodeVC)
         scanQRCodeNC.modalPresentationStyle = .fullScreen
         present(scanQRCodeNC, animated: true)
+    }
+
+    func presentViewControllerForLinkImport() {
+        let alert = UIAlertController(title: tr("addTunnelMenuFromLink"), message: nil, preferredStyle: .alert)
+        alert.addTextField { textField in
+            textField.placeholder = "https://"
+            textField.keyboardType = .URL
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+        }
+        alert.addAction(UIAlertAction(title: tr("actionCancel"), style: .cancel))
+        alert.addAction(UIAlertAction(title: tr("actionConnect"), style: .default) { [weak self, weak alert] _ in
+            guard let self = self, let urlString = alert?.textFields?.first?.text, let url = URL(string: urlString) else {
+                ErrorPresenter.showErrorAlert(title: tr("alertBadConfigImportTitle"), message: tr("alertInvalidURLErrorMessage"), from: self)
+                return
+            }
+            self.busyIndicator.startAnimating()
+            let task = URLSession.shared.dataTask(with: url) { data, _, error in
+                DispatchQueue.main.async { self.busyIndicator.stopAnimating() }
+                if let error = error {
+                    DispatchQueue.main.async {
+                        ErrorPresenter.showErrorAlert(title: tr("alertBadConfigImportTitle"), message: error.localizedDescription, from: self)
+                    }
+                    return
+                }
+                guard let data = data else {
+                    DispatchQueue.main.async {
+                        ErrorPresenter.showErrorAlert(title: tr("alertBadConfigImportTitle"), message: tr("alertInvalidURLErrorMessage"), from: self)
+                    }
+                    return
+                }
+                do {
+                    struct ConfigResponse: Decodable { let config: String }
+                    let response = try JSONDecoder().decode(ConfigResponse.self, from: data)
+                    let name = url.deletingPathExtension().lastPathComponent
+                    let tunnelConfiguration = try TunnelConfiguration(fromWgQuickConfig: response.config, called: name)
+                    self.tunnelsManager?.add(tunnelConfiguration: tunnelConfiguration) { result in
+                        if case .failure(let error) = result {
+                            DispatchQueue.main.async {
+                                ErrorPresenter.showErrorAlert(error: error, from: self)
+                            }
+                        }
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        ErrorPresenter.showErrorAlert(title: tr("alertBadConfigImportTitle"), message: error.localizedDescription, from: self)
+                    }
+                }
+            }
+            task.resume()
+        })
+        present(alert, animated: true)
     }
 
     @objc func selectButtonTapped() {


### PR DESCRIPTION
## Summary
- allow adding tunnel configurations from a URL link
- provide UI for entering link and fetching config JSON
- localize new menu item and action strings

## Testing
- `swift test` *(fails: 'wireguard-apple': Invalid manifest)*

------
https://chatgpt.com/codex/tasks/task_e_689b50106b3c832f925592819737b48e